### PR TITLE
プレイヤー退出時刻が記録されるように修正

### DIFF
--- a/VRChatLifelog.Tests/VRChatLogUtilTest.cs
+++ b/VRChatLifelog.Tests/VRChatLogUtilTest.cs
@@ -33,15 +33,16 @@ namespace VRChatLifelogTest
         }
 
         [Theory]
-        [InlineData("[Behaviour] OnPlayerLeft hoge (usr_7c61377d-df7c-4cbe-a486-c8caad0d22de)", "hoge")]
-        [InlineData("[Behaviour] OnPlayerLeft テスト用 (usr_dc868ae9-678a-4c4d-8a5d-e51611ba5c28)", "テスト用")]
-        public void Parse_Valid_PlayerLeftLog(string log, string playerName)
+        [InlineData("[Behaviour] OnPlayerLeft hoge (usr_7c61377d-df7c-4cbe-a486-c8caad0d22de)", "hoge", "usr_7c61377d-df7c-4cbe-a486-c8caad0d22de")]
+        [InlineData("[Behaviour] OnPlayerLeft テスト用 (usr_dc868ae9-678a-4c4d-8a5d-e51611ba5c28)", "テスト用", "usr_dc868ae9-678a-4c4d-8a5d-e51611ba5c28")]
+        public void Parse_Valid_PlayerLeftLog(string log, string playerName, string playerId)
         {
             var isSuccess = VRChatLogUtil.TryParsePlayerLeftLog(log, out var leftLog);
             Assert.True(isSuccess);
             Assert.NotNull(leftLog);
 
-            Assert.Equal(playerName, leftLog!.PlayerName);
+            Assert.Equal(playerName, leftLog.PlayerName);
+            Assert.Equal(playerId, leftLog.PlayerId);
         }
 
         [Theory]

--- a/VRChatLifelog.Tests/VRChatLogUtilTest.cs
+++ b/VRChatLifelog.Tests/VRChatLogUtilTest.cs
@@ -33,8 +33,8 @@ namespace VRChatLifelogTest
         }
 
         [Theory]
-        [InlineData("[Behaviour] Unregistering hoge", "hoge")]
-        [InlineData("[Behaviour] Unregistering テスト用", "テスト用")]
+        [InlineData("[Behaviour] OnPlayerLeft hoge (usr_7c61377d-df7c-4cbe-a486-c8caad0d22de)", "hoge")]
+        [InlineData("[Behaviour] OnPlayerLeft テスト用 (usr_dc868ae9-678a-4c4d-8a5d-e51611ba5c28)", "テスト用")]
         public void Parse_Valid_PlayerLeftLog(string log, string playerName)
         {
             var isSuccess = VRChatLogUtil.TryParsePlayerLeftLog(log, out var leftLog);

--- a/VRChatLifelog/Models/VRChatLogUtil.cs
+++ b/VRChatLifelog/Models/VRChatLogUtil.cs
@@ -8,7 +8,7 @@ public static class VRChatLogUtil
 {
     private static readonly Regex PlayerJoinLogPattern = new("\\[Behaviour\\] Initialized PlayerAPI \"(?<player>.*)\" is (?<type>(remote)|(local))");
 
-    private static readonly Regex PlayerLeftLogPattern = new(@"\[Behaviour\] Unregistering (?<player>.*)");
+    private static readonly Regex PlayerLeftLogPattern = new(@"\[Behaviour\] OnPlayerLeft (?<player>.*) \((?<playerId>.*)\)");
 
     //lang=regex
     private static readonly Regex WorldJoinLogPattern = new(

--- a/VRChatLifelog/Models/VRChatLogUtil.cs
+++ b/VRChatLifelog/Models/VRChatLogUtil.cs
@@ -60,8 +60,9 @@ public static class VRChatLogUtil
         }
 
         var playerName = match.Groups["player"].Value;
+        var playerId = match.Groups["playerId"].Value;
 
-        leftLog = new PlayerLeftLog(playerName);
+        leftLog = new PlayerLeftLog(playerName, playerId);
         return true;
     }
 
@@ -156,7 +157,8 @@ public record PlayerJoinLog(string PlayerName, bool IsLocal);
 /// プレイヤーLeftログ
 /// </summary>
 /// <param name="PlayerName">プレイヤー名</param>
-public record PlayerLeftLog(string PlayerName);
+/// <param name="PlayerId"プレイヤーID</param>
+public record PlayerLeftLog(string PlayerName, string PlayerId);
 
 /// <summary>
 /// ルームJoinログ


### PR DESCRIPTION
- プレイヤー退出時に出力されるログの変更に対応
  - 解析対象を `[Behaviour] Unregistering <player>` から `[Behaviour] OnPlayerLeft <player> (<playerId>)` に変更
  - 退出したプレイヤーのIDも取得できるように変更（記録はしていない）